### PR TITLE
Remove redundant 'uses' of github workflow

### DIFF
--- a/.github/workflows/jq.yml
+++ b/.github/workflows/jq.yml
@@ -13,7 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: docker://nanozoo/jq:1.6--0bafc15
       - name: Check if a json is sorted
         run: |
           for json in assets/json/*.json ; do


### PR DESCRIPTION
github's ubuntu-latest has installed jq by default, so we don't need jq docker
