### PR TITLE
Fix: percentage-encode url

### DIFF
--- a/autoload/search.vim
+++ b/autoload/search.vim
@@ -11,6 +11,7 @@ function! s:search(text, engine) abort
   " Replace `\n`, preserve `\`
   let text = substitute(a:text, '\n', ' ', 'g')
   let text = substitute(text, '\\', '\\\', 'g')
+  let text = search#util#url_encode(text)
 
   " If selected text contains URL
   let url_in_text = matchstr(text, '\c\<\(\%([a-z][0-9A-Za-z_-]\+:\%(\/\{1,3}\|[a-z0-9%]\)\|www\d\{0,3}[.]\|[a-z0-9.\-]\+[.][a-z]\{2,4}\/\)\%([^ \t()<>]\+\|(\([^ \t()<>]\+\|\(([^ \t()<>]\+)\)\)*)\)\+\%((\([^ \t()<>]\+\|\(([^ \t()<>]\+)\)\)*)\|[^ \t`!()[\]{};:'."'".'".,<>?«»“”‘’]\)\)')

--- a/autoload/search/util.vim
+++ b/autoload/search/util.vim
@@ -61,3 +61,49 @@ function! search#util#get_selected_text() abort
   let text = text[col1-1 : col2-1]
   return text
 endfunction
+
+" https://vi.stackexchange.com/questions/42717/how-do-i-turn-a-string-into-url-encoded-string
+" URL encode a string. ie. Percent-encode characters as necessary.
+function! search#util#url_encode(string)
+
+    let result = ""
+
+    let characters = split(a:string, '.\zs')
+    for character in characters
+        if character == " "
+            let result = result . "+"
+        elseif CharacterRequiresUrlEncoding(character)
+            let i = 0
+            while i < strlen(character)
+                let byte = strpart(character, i, 1)
+                let decimal = char2nr(byte)
+                let result = result . "%" . printf("%02x", decimal)
+                let i += 1
+            endwhile
+        else
+            let result = result . character
+        endif
+    endfor
+
+    return result
+
+endfunction
+
+" Returns 1 if the given character should be percent-encoded in a URL encoded
+" string.
+function! CharacterRequiresUrlEncoding(character)
+
+    let ascii_code = char2nr(a:character)
+    if ascii_code >= 48 && ascii_code <= 57
+        return 0
+    elseif ascii_code >= 65 && ascii_code <= 90
+        return 0
+    elseif ascii_code >= 97 && ascii_code <= 122
+        return 0
+    elseif a:character == "-" || a:character == "_" || a:character == "." || a:character == "~"
+        return 0
+    endif
+
+    return 1
+
+endfunction


### PR DESCRIPTION
On Windows, CMD can't handle unicode characters. If the search term contains unicode characters, they will be replaced by `?` in CMD.

This PR percentage-encodes unicode characters so they can be passed correctly into CMD.